### PR TITLE
NumPy 1.16.6+security.2: backport CVE-2021-41496 (f2py array_from_pyobj)

### DIFF
--- a/doc/changelog/1.16.6+security.2-changelog.rst
+++ b/doc/changelog/1.16.6+security.2-changelog.rst
@@ -1,0 +1,15 @@
+
+Contributors
+============
+
+A total of 1 person contributed to this release.
+
+* Warren Weckesser
+
+
+Pull requests merged
+====================
+
+A total of 1 pull request was merged for this release.
+
+* `#20630 <https://github.com/numpy/numpy/pull/20630>`__: BUG: f2py: Simplify creation of an exception message. Closes gh-19000.

--- a/doc/release/1.16.6+security.2-notes.rst
+++ b/doc/release/1.16.6+security.2-notes.rst
@@ -1,0 +1,61 @@
+==================================
+NumPy 1.16.6+security.2 Release Notes
+==================================
+
+The NumPy 1.16.6+security.2 release backports a CVE fix for the f2py
+``array_from_pyobj`` function. It is an ActiveState security release on the
+1.16.6 line (the prior security release, tagged 1.16.6.1, is treated as
+``+security.1``).
+
+Downstream developers building this release should use Cython >= 0.29.2 and, if
+using OpenBLAS, OpenBLAS >= v0.3.7. The supported Python versions are 2.7 and
+3.5-3.7.
+
+- Deal with CVE-2021-41496
+
+Two further advisories were assessed for this release and found not to require
+a code change (both are documented for tracking purposes):
+
+- CVE-2021-33430 (GHSA-6p56-wp2h-9hxr) -- the ``PyArray_NewFromDescr_int``
+  stack-buffer bounds check is already present in this line ahead of the
+  ``descr->subarray`` ``memcpy``; not applicable.
+- CVE-2021-34141 (GHSA-fpfv-jqm9-f5jm) -- disputed; the deprecated
+  Numeric-style typecode comparison only affects a ``DeprecationWarning``, not
+  the resolved dtype, so there is no security impact and no upstream fix to
+  backport.
+
+Highlights
+==========
+
+- Fix for CVE-2021-41496: a stack buffer overflow in the f2py
+  ``array_from_pyobj`` error path when an intent(cache|hide)|optional array is
+  passed negative dimensions. Backported from numpy/numpy PR #20630
+  (commit 271010f1037150e9, closes gh-19000).
+
+
+New functions
+=============
+
+
+Compatibility notes
+===================
+
+
+Improvements
+============
+
+
+Contributors
+============
+
+A total of 1 person contributed to this release.
+
+* Warren Weckesser
+
+
+Pull requests merged
+====================
+
+A total of 1 pull request was merged for this release.
+
+* `#20630 <https://github.com/numpy/numpy/pull/20630>`__: BUG: f2py: Simplify creation of an exception message. Closes gh-19000.

--- a/numpy/f2py/src/fortranobject.c
+++ b/numpy/f2py/src/fortranobject.c
@@ -595,14 +595,15 @@ static int check_and_fix_dimensions(const PyArrayObject* arr,
                                     npy_intp *dims);
 
 static int
-count_negative_dimensions(const int rank,
-                          const npy_intp *dims) {
-    int i=0,r=0;
-    while (i<rank) {
-        if (dims[i] < 0) ++r;
-        ++i;
+find_first_negative_dimension(const int rank,
+                              const npy_intp *dims) {
+    int i;
+    for (i = 0; i < rank; ++i) {
+        if (dims[i] < 0) {
+            return i;
+        }
     }
-    return r;
+    return -1;
 }
 
 #ifdef DEBUG_COPY_ND_ARRAY
@@ -679,14 +680,12 @@ PyArrayObject* array_from_pyobj(const int type_num,
         || ((intent & F2PY_OPTIONAL) && (obj==Py_None))
         ) {
         /* intent(cache), optional, intent(hide) */
-        if (count_negative_dimensions(rank,dims) > 0) {
-            int i;
-            strcpy(mess, "failed to create intent(cache|hide)|optional array"
-                   "-- must have defined dimensions but got (");
-            for(i=0;i<rank;++i)
-                sprintf(mess+strlen(mess),"%" NPY_INTP_FMT ",",dims[i]);
-            strcat(mess, ")");
-            PyErr_SetString(PyExc_ValueError,mess);
+        int i = find_first_negative_dimension(rank, dims);
+        if (i >= 0) {
+            PyErr_Format(PyExc_ValueError,
+                         "failed to create intent(cache|hide)|optional array"
+                         " -- must have defined dimensions, but dims[%d] = %"
+                         NPY_INTP_FMT, i, dims[i]);
             return NULL;
         }
         arr = (PyArrayObject *)

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,10 @@ MINOR               = 16
 MICRO               = 6
 ISRELEASED          = True
 VERSION             = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
+# ActiveState security release: PEP 440 local version label. N counts the
+# ActiveState security releases on this line (1.16.6.1 was security.1).
+AS_SECURITY         = '+security.2'
+VERSION             = VERSION + AS_SECURITY
 
 
 # Return the git revision as a string


### PR DESCRIPTION
ActiveState security release on the 1.16.6 line (DE-8118).

## Fixed
- **CVE-2021-41496** (GHSA-f7c7-j99h-c22f) — stack buffer overflow in the f2py `array_from_pyobj` error path: it built a "must have defined dimensions" message into a fixed 200-byte `mess[]` buffer via `strcpy` + a `sprintf` loop over up to `F2PY_MAX_DIMS` (40) dims + `strcat`, which can overflow with enough negative dimensions (local DoS). Backported upstream `271010f1037150e9` (PR numpy/numpy#20630, closes gh-19000): replaces `count_negative_dimensions()` with `find_first_negative_dimension()` and emits a single bounded `PyErr_Format()`. Kept a C89-style loop var for older-MSVC compatibility (cf. the CVE-2021-41495 compiler fixups).

## Assessed — not applicable (table-only)
- **CVE-2021-33430** (GHSA-6p56-wp2h-9hxr) — already mitigated here: the `nd > NPY_MAXDIMS` guard is present at `ctors.c:934`, ahead of the `descr->subarray` `memcpy`.
- **CVE-2021-34141** (GHSA-fpfv-jqm9-f5jm) — disputed; the deprecated Numeric-style typecode `strncmp` only affects a `DeprecationWarning`, not the resolved dtype. No upstream security fix.

## Release
- Version bumped to the PEP 440 local form **`1.16.6+security.2`** in `setup.py` so the installed package self-reports the security level (`1.16.6.1` == security.1).
- Added `doc/release/1.16.6+security.2-notes.rst` + changelog.

## Validation
C89 syntax-checked (incl. `-Wdeclaration-after-statement`); `setup.py` compiles and reports `1.16.6+security.2`; `NumpyVersion()` tolerates the `+local` label. The f2py change is not runnable in this environment (build-generated `_numpyconfig.h`); it relies on the build pipeline (upstream shipped the same change without an added test).
